### PR TITLE
Added missing GO env vars to build for different platforms

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,6 +63,10 @@ tasks:
     cmds:
       - go build -ldflags "-X github.com/amido/stacks-cli/cmd.version={{.BUILDNUMBER}}" -o {{.OUTPUT_BIN_DIR}}/stacks-cli-{{.PLATFORM_OS}}-{{.PLATFORM_ARCH}}-{{.BUILDNUMBER}}{{.PLATFORM_EXTENSION}}
   
+    env:
+      GOOS: '{{ .PLATFORM_OS }}'
+      GOARCH: '{{ .PLATFORM_ARCH }}'
+
   compile:
     desc: Compile supports platforms
 


### PR DESCRIPTION
Slack CLI binaries were being created for the platform on which the app was compiled. This was because the environment variables had not been set properly, e.g. GOOS and GOARCH.

This is now being set properly and the cross compilation is now working as it should.

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>