### PR TITLE
Added public method to get framework details

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	github.com/spf13/viper v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20211020174200-9d6173849985 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/amido/stacks-cli/internal/config/static"
 	"github.com/amido/stacks-cli/internal/constants"
 	"github.com/amido/stacks-cli/internal/util"
 	"github.com/bobesa/go-domain-util/domainutil"
@@ -385,4 +386,18 @@ func (config *Config) OpenOnlineHelp(cliCmd string, logger *logrus.Logger) bool 
 	}
 
 	return result
+}
+
+// GetFrameworks gets the static configuration of the stacks frameworks and
+// unmarshals it into a returning InputConfig object
+// This is so that the configuration can be read by other apps based on the CLI
+func (config *Config) GetFrameworks() (Stacks, error) {
+
+	var err error
+
+	// get the static configuration
+	stacks_frameworks := static.Config("stacks_frameworks")
+	err = yaml.Unmarshal(stacks_frameworks, &config.Input)
+
+	return config.Input.Stacks, err
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -667,3 +667,15 @@ func TestGetFrameworkCommands(t *testing.T) {
 		}
 	}
 }
+
+func TestGetFrameworks(t *testing.T) {
+
+	config := Config{}
+
+	// attempt to get the stacks as a model
+	stacks, err := config.GetFrameworks()
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "https://github.com/amido/stacks-dotnet", stacks.Dotnet.Webapi.URL)
+
+}

--- a/testing/integration/base_integration.go
+++ b/testing/integration/base_integration.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/amido/stacks-cli/internal/config/static"
 	"github.com/amido/stacks-cli/internal/util"
 	"github.com/amido/stacks-cli/pkg/config"
 	yaml "github.com/goccy/go-yaml"
@@ -101,10 +100,18 @@ func (suite *BaseIntegration) WriteConfigFile(filename string) string {
 	// read in the static frameworks so that they can be added to the configuration file
 	// this is so that they have a value and are not null which will prevent the CLI
 	// from working properly
-	stacks_frameworks := string(static.Config("stacks_frameworks"))
+	/*
+		stacks_frameworks := string(static.Config("stacks_frameworks"))
 
-	stacks := config.InputConfig{}
-	err := yaml.Unmarshal([]byte(stacks_frameworks), &stacks)
+		stacks := config.InputConfig{}
+		err := yaml.Unmarshal([]byte(stacks_frameworks), &stacks)
+		if err != nil {
+			suite.T().Fatalf("Error setting stacks frameworks: %s", err.Error())
+		}
+	*/
+
+	cfg := config.Config{}
+	stacks, err := cfg.GetFrameworks()
 	if err != nil {
 		suite.T().Fatalf("Error setting stacks frameworks: %s", err.Error())
 	}
@@ -189,7 +196,7 @@ func (suite *BaseIntegration) WriteConfigFile(filename string) string {
 				},
 			},
 		},
-		Stacks: stacks.Stacks,
+		Stacks: stacks,
 		Terraform: config.Terraform{
 			Backend: config.TerraformBackend{
 				Storage:   tf_storage,


### PR DESCRIPTION
Allow static configuration to be accessible publicly

#### 📲 What

Added a new function to allow the Stacks framework configuration to be exported as a model

#### 🤔 Why
		
The static configuration is an internal component so it cannot be accessed byu projects that consume the CLI as a library.
		
#### 🛠 How
		
Created a new method called `GetFrameworks` which will return the Stacks object model
		 
#### 🕵️ How to test

All integration tests are being run and are passing with the new configuration system.
