### PR TITLE
fix failing unit tests from previous change

### DIFF
--- a/pkg/config/stacks_test.go
+++ b/pkg/config/stacks_test.go
@@ -93,7 +93,7 @@ func setupTestCase(t *testing.T, configuration []byte) (func(t *testing.T), stri
 
 func TestStacksComponents(t *testing.T) {
 
-	var expected int = 8
+	var expected int = 9
 
 	config := Config{}
 	config.Init()
@@ -128,7 +128,7 @@ func TestStacksComponents(t *testing.T) {
 }
 
 func TestOverriddenStacksComponents(t *testing.T) {
-	var expected int = 10
+	var expected int = 11
 
 	config := Config{}
 	config.Init()
@@ -281,12 +281,12 @@ func TestGetComponentOptionsDefault(t *testing.T) {
 		},
 		{
 			"infra",
-			[]string{"aks"},
+			[]string{"aks","data"},
 			false,
 		},
 		{
 			"infra",
-			[]string{"aks", "keyvault"},
+			[]string{"aks", "data", "keyvault"},
 			true,
 		},
 		{


### PR DESCRIPTION
#### 📲 What

Fix failing unit tests from previous change.

#### 🤔 Why
		
Seems like when 'data' was added, 3 unit tests failed.
There seems to be an issue with Invoke-UnitTests.ps1 so if unit tests fail the pipeline doesn't fail
		
#### 🛠 How
		
Updated the expected count and added 'data' to component list


![image](https://github.com/Ensono/stacks-cli/assets/47520690/0aa508e5-2d0d-4459-8e53-30eec4ee1e46)

