### PR TITLE
Feat/6814 support multiple pipelines

### DIFF
--- a/internal/config/staticFiles/config.yml
+++ b/internal/config/staticFiles/config.yml
@@ -103,7 +103,7 @@ stacks:
       name: data
       package:
         url: https://github.com/amido/stacks-azure-data-ingest
-        version: feat/6814-stack-cli-changes
+        version: master
         type: git
 
 help:

--- a/internal/config/staticFiles/config.yml
+++ b/internal/config/staticFiles/config.yml
@@ -103,7 +103,7 @@ stacks:
       name: data
       package:
         url: https://github.com/amido/stacks-azure-data-ingest
-        version: master
+        version: feat/6814-stack-cli-changes
         type: git
 
 help:

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -52,7 +52,7 @@ type SettingsFrameworkCommands struct {
 	Version string `mapstructure:"version"`
 }
 
-// GetPipelines attempts to return the pipeline settings for the named pipeline
+// GetPipelines attempts to return all pipelines settings for the named pipeline
 func (s *Settings) GetPipelines(name string) []Pipeline {
 	pipeline := []Pipeline{}
 

--- a/pkg/config/settings.go
+++ b/pkg/config/settings.go
@@ -52,16 +52,15 @@ type SettingsFrameworkCommands struct {
 	Version string `mapstructure:"version"`
 }
 
-// GetPipeline attempts to return the pipeline settings for the named pipeline
-func (s *Settings) GetPipeline(name string) Pipeline {
-	pipeline := Pipeline{}
+// GetPipelines attempts to return the pipeline settings for the named pipeline
+func (s *Settings) GetPipelines(name string) []Pipeline {
+	pipeline := []Pipeline{}
 
-	// iterate around the pipeline slice and find the one with the type that matches
-	// the specified name
+	// iterate around the pipeline slice and find the ones with the type that matches
+	// the specified name.
 	for _, p := range s.Pipeline {
 		if p.Type == name {
-			pipeline = p
-			break
+			pipeline = append(pipeline, p)
 		}
 	}
 

--- a/pkg/config/settings_test.go
+++ b/pkg/config/settings_test.go
@@ -43,7 +43,7 @@ func TestPipelineExists(t *testing.T) {
 	// get the settings from the setup
 	settings := setupPipelines(t)
 
-	assert.NotEqual(t, Pipeline{}, settings.GetPipeline("azdo"))
+	assert.NotEqual(t, []Pipeline{}, settings.GetPipelines("azdo"))
 }
 
 func TestPipelineDoesNotExist(t *testing.T) {
@@ -51,7 +51,17 @@ func TestPipelineDoesNotExist(t *testing.T) {
 	// get the settings from the setup
 	settings := setupPipelines(t)
 
-	assert.Equal(t, Pipeline{}, settings.GetPipeline("jenkins"))
+	assert.Equal(t, []Pipeline{}, settings.GetPipelines("jenkins"))
+}
+
+func TestPipelineReturnCount(t *testing.T) {
+
+	// get the settings from the setup
+	settings := setupPipelines(t)
+
+	pipelineCount := len(settings.GetPipelines("azdo"))
+
+	assert.Equal(t, 1, pipelineCount)
 }
 
 func TestFrameworkCommandVersions(t *testing.T) {

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -379,36 +379,39 @@ func (s *Scaffold) configurePipeline(project *config.Project) {
 	}
 
 	// get the pipeline settings
-	pipelineSettings := project.Settings.GetPipeline(s.Config.Input.Pipeline)
+	pipelineSettingsList := project.Settings.GetPipelines(s.Config.Input.Pipeline)
 
-	// define the replacements object so that all can be passed to the render function
-	// the project is passed in a separate project as it is part of a slice
-	replacements := config.Replacements{}
-	replacements.Input = s.Config.Input
-	replacements.Project = *project
+	for _, pipelineSettings := range pipelineSettingsList {
 
-	// attempt to write out the configuration file, unless in DryRun mode
-	if s.Config.Input.Options.DryRun {
-		s.Logger.Warn("Not creating variables template as in DRYRUN mode")
-	} else {
-		msg, err := s.Config.WriteVariablesFile(project, pipelineSettings, replacements)
+		// define the replacements object so that all can be passed to the render function
+		// the project is passed in a separate project as it is part of a slice
+		replacements := config.Replacements{}
+		replacements.Input = s.Config.Input
+		replacements.Project = *project
 
-		if err == nil {
-			if msg == "" {
-				s.Logger.Info("Created pipeline variable file")
-			} else {
-				s.Logger.Warn(msg)
-			}
+		// attempt to write out the configuration file, unless in DryRun mode
+		if s.Config.Input.Options.DryRun {
+			s.Logger.Warn("Not creating variables template as in DRYRUN mode")
 		} else {
-			s.Logger.Error(msg)
-		}
-	}
+			msg, err := s.Config.WriteVariablesFile(project, pipelineSettings, replacements)
 
-	// perform any addition regex replacements
-	errs := pipelineSettings.ReplacePatterns(project.Directory.WorkingDir)
-	if len(errs) > 0 {
-		for _, err := range errs {
-			s.Logger.Error(err.Error())
+			if err == nil {
+				if msg == "" {
+					s.Logger.Info("Created pipeline variable file")
+				} else {
+					s.Logger.Warn(msg)
+				}
+			} else {
+				s.Logger.Error(msg)
+			}
+		}
+
+		// perform any addition regex replacements
+		errs := pipelineSettings.ReplacePatterns(project.Directory.WorkingDir)
+		if len(errs) > 0 {
+			for _, err := range errs {
+				s.Logger.Error(err.Error())
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### 📲 What

Support multiple pipeline files

#### 🤔 Why
		
Being able to support multiple pipeline files. 
The stacks data project has multiple files that need to be replaced.
		
#### 🛠 How
		
Updated GetPipeline to GetPipelines
Rather than returning the first pipeline of that type, it now returns all the pipelines that match that type.
We then loop through each pipeline and run the same code as before.

Fixed and added a new unit test

#### Evidence
stackscli.yml - here we have two files that need replacing
![image](https://github.com/Ensono/stacks-cli/assets/47520690/45652efd-ad25-472c-8b81-3f018299188e)

here is the template file for the first file: air-infrastructure-data-template.yml
![image](https://github.com/Ensono/stacks-cli/assets/47520690/18c6334a-cb0c-4851-9ba2-fc4214d4db0c)

here is the generated file for the first file:  air-infrastructure-data.yml
![image](https://github.com/Ensono/stacks-cli/assets/47520690/b5cbd0ad-f944-4a25-95d3-7cd8bf45ad2d)

here is the template file for the second file: common-vars-template.yml
![image](https://github.com/Ensono/stacks-cli/assets/47520690/83a60ad3-7306-4a87-9467-d091b15bfb97)

here is the generated file for the second file:  common-vars.yml
![image](https://github.com/Ensono/stacks-cli/assets/47520690/4bf61944-6718-44c9-be49-7d80eeb919ef)