### PR TITLE
Update installation.adoc to allow redirects when using 'curl'

### DIFF
--- a/docs/usage/installation.adoc
+++ b/docs/usage/installation.adoc
@@ -7,10 +7,10 @@ As the CLI is a single binary the quickest way to install it is to download it a
 ----
 # Download the binary to a location in the PATH
 ## Mac OS
-curl https://github.com/Ensono/stacks-cli/releases/download/v{stackscli_version}/stacks-cli-darwin-amd64-{stackscli_version} -o /usr/local/bin/stacks-cli
+curl -L https://github.com/Ensono/stacks-cli/releases/download/v{stackscli_version}/stacks-cli-darwin-amd64-{stackscli_version} -o /usr/local/bin/stacks-cli
 
 ## Linux
-curl https://github.com/Ensono/stacks-cli/releases/download/v{stackscli_version}/stacks-cli-linux-amd64-{stackscli_version} -o /usr/local/bin/stacks-cli
+curl -L https://github.com/Ensono/stacks-cli/releases/download/v{stackscli_version}/stacks-cli-linux-amd64-{stackscli_version} -o /usr/local/bin/stacks-cli
 
 ## Ensure that the command is executable
 chmod +x /usr/local/bin/stacks-cli


### PR DESCRIPTION
#### 📲 What

Updated the CLI installation instructions to allow redirects when using `curl` on Mac OS and Linux

#### 🤔 Why
		
The `curl` command to download and install the CLI doesn't work on Mac OS or Linux because `curl` does not redirect by default on these platforms.

#### 🛠 How
		
n/a

#### 👀 Evidence
		
- https://stackoverflow.com/questions/41156458/powershell-curl-and-webrequest-both-follow-redirects
- https://curl.se/docs/manpage.html#-L


![Screenshot from 2024-09-19 10-50-03](https://github.com/user-attachments/assets/f5d7eabd-c22e-4735-a627-c35db3e3fc4f)
		 
#### 🕵️ How to test



#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
