### PR TITLE
Fixed issue publoshing binaries

### DIFF
--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -24,10 +24,6 @@ stages:
     jobs:
       - job: Build
         steps:
-          # Do not perform a shallow checkout of the repo
-          - checkout: self
-            fetchDepth: 0
-
           # Install Taskfile for the build to run
           - task: Bash@3
             displayName: Install Taskctl

--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -24,6 +24,10 @@ stages:
     jobs:
       - job: Build
         steps:
+          # Do not perform a shallow checkout of the repo
+          - checkout: self
+            fetchDepth: 0
+
           # Install Taskfile for the build to run
           - task: Bash@3
             displayName: Install Taskctl

--- a/build/scripts/Invoke-Compile.ps1
+++ b/build/scripts/Invoke-Compile.ps1
@@ -22,7 +22,11 @@ param (
 
     [string[]]
     # architecture that should be targeted
-    $arch = @("amd64")
+    $arch = @("amd64"),
+
+    [switch]
+    # specify if the VCS status should be built into the go binaries
+    $NoVCS
 )
 
 # If the base directory does not exist, create it
@@ -35,9 +39,15 @@ if (!(Test-Path -Path $BasePath)) {
 $cmd = "go get"
 Invoke-Expression -Command $cmd
 
+# Set up the go build argument for vcs
+$build_vcs = ""
+if ($NoVCS.IsPresent) {
+    $build_vcs = "-buildvcs=false"
+}
+
 # iterate around each of the target os
 foreach ($os in $targets) {
-    
+
     # get a list of the architectures to build for this OS
     $archs = $arch
 
@@ -76,9 +86,10 @@ foreach ($os in $targets) {
         Write-Output ("Building for '{0}' ({1})" -f $os, $_arch)
 
         # Build up the command to create the CLI binary
-        $cmd = 'go build -ldflags "-X github.com/Ensono/stacks-cli/cmd.version={0}" -o {1}' -f
+        $cmd = 'go build -ldflags "-X github.com/Ensono/stacks-cli/cmd.version={0}" -o {1} {2}' -f
                     $BuildNumber,
-                    $cli_filename
+                    $cli_filename,
+                    $build_vcs
 
         Invoke-Expression -Command $cmd
 
@@ -93,6 +104,3 @@ foreach ($os in $targets) {
 
     }
 }
-
-
-

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -15,7 +15,7 @@ tasks:
     description: Compile CLI and Integration Tests
     context: buildenv
     command:
-      - /app/build/scripts/Invoke-Compile.ps1 -BuildNumber $BUILDNUMBER
+      - /app/build/scripts/Invoke-Compile.ps1 -BuildNumber $BUILDNUMBER -NoVCS
 
   _docs:
     description: Build Docs for Stacks CLI


### PR DESCRIPTION
#### 📲 What

Added flags to the `go build` command line to stop the VCS status being added to the binaries.

#### 🤔 Why
		
Since the last PR and the upgrade of Go, the binaries for the platforms have not been built or published.

By default Go tries to get tags from the VCS system, however this is not working Azure DevOps - even with a full clone of the repo.

The parameter to set te VCS status is now true in Go as of version 1.18.

![image](https://github.com/user-attachments/assets/e20ba3da-bbf9-4109-8f23-3ae3105f9a04)
		
#### 🛠 How
		
Added an option to the `Invoke-Compile` script called `NoVCS`. When this is added as a parameter to the build, the `go build` command has the `-buildvcs=false` option appended to it. This stops the error that was being seen.

#### 👀 Evidence
		
All artifacts are now uploaded and not just the integration tests

![image](https://github.com/user-attachments/assets/ef811c7c-8195-46ad-840b-36361a065c56)

		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
