### PR TITLE
fix(): bump x/net from v0.23.0 → v0.33.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20231127185646-65229373498e // indirect
-	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect


### PR DESCRIPTION
#### 📲 What

bump x/net from v0.23.0 → v0.33.0 to mitigate CVE-2024-45338

#### 🤔 Why
		
We maintain Ensono Stacks in line with our responsibilities under ISO 27001 and Cyber Essentials.
		
#### 🛠 How
		
Update go module.

#### 👀 Evidence

```		
INFO[0005] test:unit finished. Duration 5.097158361s    
```
		 
#### 🕵️ How to test

Build pipeline.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [x] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [X] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
