### PR TITLE
fix(): 11s/veriable/variable/g

### DIFF
--- a/build/azuredevops-taskctl.yml
+++ b/build/azuredevops-taskctl.yml
@@ -7,7 +7,7 @@ name: 0.4$(Rev:.r)
 
 # Set the agent pool that is going to be used for the build
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-24.04
 
 parameters:
   - name: pre_release

--- a/docs/appendix.adoc
+++ b/docs/appendix.adoc
@@ -8,7 +8,7 @@ A number of items are embedded using this technique.
 
 The following listing shows the built in template that is used for the variable template if one is not set in the project settings file.
 
-Location: `internal/config/staticFiles/ado_veriable_template.yml`
+Location: `internal/config/staticFiles/ado_variable_template.yml`
 
 .Azure DevOps Variable Template
 [[azdo_variable_template,{listing-caption} {counter:refnum}]]


### PR DESCRIPTION
#### 📲 What

Single character substitution error in `appendix.adoc`.

Fixes a spelling error in the documentation, correcting "veriable" to "variable" in the file path reference within `appendix.adoc`.

- Corrects a typo in a file path reference from "ado_veriable_template.yml" to "ado_variable_template.yml",
- Updates the `vmPoolImage` to ubuntu-24.04 as 20.04 is no longer available in Azure DevOps.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [X] Rebased/merged with latest changes from development and re-tested?
- [X] Meeting the Coding Standards?